### PR TITLE
make it compile on vivado also

### DIFF
--- a/rtl/T80/T80.vhd
+++ b/rtl/T80/T80.vhd
@@ -126,6 +126,127 @@ entity T80 is
 end T80;
 
 architecture rtl of T80 is
+	component T80_MCode is
+		generic(
+			Mode   : integer := 0;
+			Flag_C : integer := 0;
+			Flag_N : integer := 1;
+			Flag_P : integer := 2;
+			Flag_X : integer := 3;
+			Flag_H : integer := 4;
+			Flag_Y : integer := 5;
+			Flag_Z : integer := 6;
+			Flag_S : integer := 7
+		);
+		port(
+		  IR          : in std_logic_vector(7 downto 0);
+		  ISet        : in std_logic_vector(1 downto 0);
+		  MCycle      : in std_logic_vector(2 downto 0);
+		  F           : in std_logic_vector(7 downto 0);
+		  NMICycle    : in std_logic;
+		  IntCycle    : in std_logic;
+		  XY_State    : in std_logic_vector(1 downto 0);
+		  MCycles     : out std_logic_vector(2 downto 0);
+		  TStates     : out std_logic_vector(2 downto 0);
+		  Prefix      : out std_logic_vector(1 downto 0); -- None,CB,ED,DD/FD
+		  Inc_PC      : out std_logic;
+		  Inc_WZ      : out std_logic;
+		  IncDec_16   : out std_logic_vector(3 downto 0); -- BC,DE,HL,SP   0 is inc
+		  Read_To_Reg : out std_logic;
+		  Read_To_Acc : out std_logic;
+		  Set_BusA_To : out std_logic_vector(3 downto 0); -- B,C,D,E,H,L,DI/DB,A,SP(L),SP(M),0,F
+		  Set_BusB_To : out std_logic_vector(3 downto 0); -- B,C,D,E,H,L,DI,A,SP(L),SP(M),1,F,PC(L),PC(M),0
+		  ALU_Op      : out std_logic_vector(3 downto 0);
+			 -- ADD, ADC, SUB, SBC, AND, XOR, OR, CP, ROT, BIT, SET, RES, DAA, RLD, RRD, None
+		  Save_ALU    : out std_logic;
+		  PreserveC   : out std_logic;
+		  Arith16     : out std_logic;
+		  Set_Addr_To : out std_logic_vector(2 downto 0); -- aNone,aXY,aIOA,aSP,aBC,aDE,aZI
+		  IORQ        : out std_logic;
+		  Jump        : out std_logic;
+		  JumpE       : out std_logic;
+		  JumpXY      : out std_logic;
+		  Call        : out std_logic;
+		  RstP        : out std_logic;
+		  LDZ         : out std_logic;
+		  LDW         : out std_logic;
+		  LDSPHL      : out std_logic;
+		  Special_LD  : out std_logic_vector(2 downto 0); -- A,I;A,R;I,A;R,A;None
+		  ExchangeDH  : out std_logic;
+		  ExchangeRp  : out std_logic;
+		  ExchangeAF  : out std_logic;
+		  ExchangeRS  : out std_logic;
+		  I_DJNZ      : out std_logic;
+		  I_CPL       : out std_logic;
+		  I_CCF       : out std_logic;
+		  I_SCF       : out std_logic;
+		  I_RETN      : out std_logic;
+		  I_BT        : out std_logic;
+		  I_BC        : out std_logic;
+		  I_BTR       : out std_logic;
+		  I_RLD       : out std_logic;
+		  I_RRD       : out std_logic;
+		  I_INRC      : out std_logic;
+		  SetWZ       : out std_logic_vector(1 downto 0);
+		  SetDI       : out std_logic;
+		  SetEI       : out std_logic;
+		  IMode       : out std_logic_vector(1 downto 0);
+		  Halt        : out std_logic;
+		  NoRead      : out std_logic;
+		  Write       : out std_logic;
+		  XYbit_undoc : out std_logic
+	   );
+	end component T80_MCode;
+
+	component T80_ALU is
+		generic(
+			Mode : integer := 0;
+			Flag_C : integer := 0;
+			Flag_N : integer := 1;
+			Flag_P : integer := 2;
+			Flag_X : integer := 3;
+			Flag_H : integer := 4;
+			Flag_Y : integer := 5;
+			Flag_Z : integer := 6;
+			Flag_S : integer := 7
+		);
+		port(
+			Arith16         : in  std_logic;
+			Z16             : in  std_logic;
+			WZ              : in  std_logic_vector(15 downto 0);
+			XY_State		    : in  std_logic_vector(1 downto 0);
+			ALU_Op          : in  std_logic_vector(3 downto 0);
+			IR              : in  std_logic_vector(5 downto 0);
+			ISet            : in  std_logic_vector(1 downto 0);
+			BusA            : in  std_logic_vector(7 downto 0);
+			BusB            : in  std_logic_vector(7 downto 0);
+			F_In            : in  std_logic_vector(7 downto 0);
+			Q               : out std_logic_vector(7 downto 0);
+			F_Out           : out std_logic_vector(7 downto 0)
+		);
+	end component T80_ALU;
+	component T80_Reg is
+		port(
+			Clk     : in  std_logic;
+			CEN     : in  std_logic;
+			WEH     : in  std_logic;
+			WEL     : in  std_logic;
+			AddrA   : in  std_logic_vector(2 downto 0);
+			AddrB   : in  std_logic_vector(2 downto 0);
+			AddrC   : in  std_logic_vector(2 downto 0);
+			DIH     : in  std_logic_vector(7 downto 0);
+			DIL     : in  std_logic_vector(7 downto 0);
+			DOAH    : out std_logic_vector(7 downto 0);
+			DOAL    : out std_logic_vector(7 downto 0);
+			DOBH    : out std_logic_vector(7 downto 0);
+			DOBL    : out std_logic_vector(7 downto 0);
+			DOCH    : out std_logic_vector(7 downto 0);
+			DOCL    : out std_logic_vector(7 downto 0);
+			DOR     : out std_logic_vector(127 downto 0);
+			DIRSet  : in  std_logic;
+			DIR     : in  std_logic_vector(127 downto 0)
+		);
+	end component T80_Reg;
 
 	constant aNone              : std_logic_vector(2 downto 0) := "111";
 	constant aBC                : std_logic_vector(2 downto 0) := "000";
@@ -262,7 +383,7 @@ begin
 			 else IntE_FF2 & IntE_FF1 & IStatus & DOR(127 downto 112) & DOR(47 downto 0) & DOR(63 downto 48) & DOR(111 downto 64) &
 						std_logic_vector(PC) & std_logic_vector(SP) & std_logic_vector(R) & I & Fp & Ap & F & ACC;
 
-	mcode : work.T80_MCode
+	mcode : component T80_MCode
 		generic map(
 			Mode   => Mode,
 			Flag_C => Flag_C,
@@ -330,7 +451,7 @@ begin
 			Write       => Write,
 			XYbit_undoc => XYbit_undoc);
 
-	alu : work.T80_ALU
+	alu : component T80_ALU
 		generic map(
 			Mode   => Mode,
 			Flag_C => Flag_C,
@@ -610,7 +731,7 @@ begin
 						F(Flag_N) <= DI_Reg(7);
 						F(Flag_C) <= ioq(8);
 						F(Flag_H) <= ioq(8);
-						ioq := (ioq and x"7") xor ('0'&BusA);
+						ioq := (ioq and "000000111") xor ('0' & BusA);
 						F(Flag_P) <= not (ioq(0) xor ioq(1) xor ioq(2) xor ioq(3) xor ioq(4) xor ioq(5) xor ioq(6) xor ioq(7));
 					end if;
 
@@ -929,7 +1050,7 @@ begin
 		end if;
 	end process;
 
-	Regs : work.T80_Reg
+	Regs : component T80_Reg
 		port map(
 			Clk => CLK_n,
 			CEN => ClkEn,

--- a/rtl/T80/T80pa.vhd
+++ b/rtl/T80/T80pa.vhd
@@ -89,6 +89,51 @@ entity T80pa is
 end T80pa;
 
 architecture rtl of T80pa is
+	component T80 is
+		generic(
+			Mode   : integer := 0;  -- 0 => Z80, 1 => Fast Z80, 2 => 8080, 3 => GB
+			IOWait : integer := 0;  -- 0 => Single cycle I/O, 1 => Std I/O cycle
+			Flag_C : integer := 0;
+			Flag_N : integer := 1;
+			Flag_P : integer := 2;
+			Flag_X : integer := 3;
+			Flag_H : integer := 4;
+			Flag_Y : integer := 5;
+			Flag_Z : integer := 6;
+			Flag_S : integer := 7
+		);
+		port(
+			RESET_n    : in  std_logic;
+			CLK_n      : in  std_logic;
+			CEN        : in  std_logic;
+			WAIT_n     : in  std_logic;
+			INT_n      : in  std_logic;
+			NMI_n      : in  std_logic;
+			BUSRQ_n    : in  std_logic;
+			M1_n       : out std_logic;
+			IORQ       : out std_logic;
+			NoRead     : out std_logic;
+			Write      : out std_logic;
+			RFSH_n     : out std_logic;
+			HALT_n     : out std_logic;
+			BUSAK_n    : out std_logic;
+			A          : out std_logic_vector(15 downto 0);
+			DInst      : in  std_logic_vector(7 downto 0);
+			DI         : in  std_logic_vector(7 downto 0);
+			DO         : out std_logic_vector(7 downto 0);
+			MC         : out std_logic_vector(2 downto 0);
+			TS         : out std_logic_vector(2 downto 0);
+			IntCycle_n : out std_logic;
+			IntE       : out std_logic;
+			Stop       : out std_logic;
+			out0       : in  std_logic := '0';  -- 0 => OUT(C),0, 1 => OUT(C),255
+			REG        : out std_logic_vector(211 downto 0); -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
+
+			DIRSet     : in  std_logic := '0';
+			DIR        : in  std_logic_vector(211 downto 0) := (others => '0') -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
+		);
+
+	end component T80;
 
 	signal IntCycle_n		: std_logic;
 	signal IntCycleD_n	: std_logic_vector(1 downto 0);
@@ -109,7 +154,7 @@ begin
 
 	BUSAK_n <= BUSAK;
 
-	u0 : work.T80
+	u0 : component T80
 		generic map(
 			Mode    => Mode,
 			IOWait  => 1

--- a/rtl/T80/T80s.vhd
+++ b/rtl/T80/T80s.vhd
@@ -100,7 +100,52 @@ entity T80s is
 end T80s;
 
 architecture rtl of T80s is
+	component T80 is
+		generic(
+			Mode   : integer := 0;  -- 0 => Z80, 1 => Fast Z80, 2 => 8080, 3 => GB
+			IOWait : integer := 0;  -- 0 => Single cycle I/O, 1 => Std I/O cycle
+			Flag_C : integer := 0;
+			Flag_N : integer := 1;
+			Flag_P : integer := 2;
+			Flag_X : integer := 3;
+			Flag_H : integer := 4;
+			Flag_Y : integer := 5;
+			Flag_Z : integer := 6;
+			Flag_S : integer := 7
+		);
+		port(
+			RESET_n    : in  std_logic;
+			CLK_n      : in  std_logic;
+			CEN        : in  std_logic;
+			WAIT_n     : in  std_logic;
+			INT_n      : in  std_logic;
+			NMI_n      : in  std_logic;
+			BUSRQ_n    : in  std_logic;
+			M1_n       : out std_logic;
+			IORQ       : out std_logic;
+			NoRead     : out std_logic;
+			Write      : out std_logic;
+			RFSH_n     : out std_logic;
+			HALT_n     : out std_logic;
+			BUSAK_n    : out std_logic;
+			A          : out std_logic_vector(15 downto 0);
+			DInst      : in  std_logic_vector(7 downto 0);
+			DI         : in  std_logic_vector(7 downto 0);
+			DO         : out std_logic_vector(7 downto 0);
+			MC         : out std_logic_vector(2 downto 0);
+			TS         : out std_logic_vector(2 downto 0);
+			IntCycle_n : out std_logic;
+			IntE       : out std_logic;
+			Stop       : out std_logic;
+			out0       : in  std_logic := '0';  -- 0 => OUT(C),0, 1 => OUT(C),255
+			REG        : out std_logic_vector(211 downto 0); -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
+	
+			DIRSet     : in  std_logic := '0';
+			DIR        : in  std_logic_vector(211 downto 0) := (others => '0') -- IFF2, IFF1, IM, IY, HL', DE', BC', IX, HL, DE, BC, PC, SP, R, I, F', A', F, A
+		);
 
+	end component T80;
+		
 	signal IntCycle_n	: std_logic;
 	signal NoRead		: std_logic;
 	signal Write		: std_logic;
@@ -111,7 +156,7 @@ architecture rtl of T80s is
 
 begin
 
-	u0 : work.T80
+	u0 : component T80
 	generic map(
 		Mode => Mode,
 		IOWait => IOWait)

--- a/rtl/popeye.vhd
+++ b/rtl/popeye.vhd
@@ -386,6 +386,35 @@ end popeye;
 
 architecture struct of popeye is
 
+ component T80s is
+ 	generic(
+ 		Mode    : integer := 0; -- 0 => Z80, 1 => Fast Z80, 2 => 8080, 3 => GB
+ 		T2Write : integer := 1; -- 0 => WR_n active in T3, /=0 => WR_n active in T2
+ 		IOWait  : integer := 1  -- 0 => Single cycle I/O, 1 => Std I/O cycle
+ 	);
+ 	port(
+ 		RESET_n : in std_logic;
+ 		CLK     : in std_logic;
+ 		CEN     : in std_logic := '1';
+ 		WAIT_n  : in std_logic := '1';
+ 		INT_n	  : in std_logic := '1';
+ 		NMI_n	  : in std_logic := '1';
+ 		BUSRQ_n : in std_logic := '1';
+ 		M1_n    : out std_logic;
+ 		MREQ_n  : out std_logic;
+ 		IORQ_n  : out std_logic;
+ 		RD_n    : out std_logic;
+ 		WR_n    : out std_logic;
+ 		RFSH_n  : out std_logic;
+ 		HALT_n  : out std_logic;
+ 		BUSAK_n : out std_logic;
+ 		OUT0    : in  std_logic := '0';  -- 0 => OUT(C),0, 1 => OUT(C),255
+ 		A       : out std_logic_vector(15 downto 0);
+ 		DI      : in std_logic_vector(7 downto 0);
+ 		DO      : out std_logic_vector(7 downto 0)
+ 	);
+ end component T80s;
+
  signal reset_n   : std_logic;
  signal clock_vid : std_logic;
  signal clock_vidn: std_logic;
@@ -1096,7 +1125,7 @@ end process;
 ------------------------------
 
 -- microprocessor Z80
-cpu : entity work.T80s
+cpu : component T80s
 generic map(Mode => 0, T2Write => 1, IOWait => 1)
 port map(
   RESET_n => reset_n,


### PR DESCRIPTION
Vivado is much pickier in compiling VHDL.
It needs component declarations,
and the bit lengths of operands need to match.
The game runs successfully on a Xilinx XC7A100T and it still builds
with Quartus too.
(Although I had not been able to test it there yet).
But looking at the changes it is easy to reason that there will be any difference,
as the code only became more 'correct'.